### PR TITLE
Added pre and poststart scripts 

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -37,7 +37,7 @@ endif
 # Test harness
 TESTS 							 ?= $(shell ls test/*.mk 2>/dev/null)
 
-.PHONY = all install distclean clean testclean test
+.PHONY: install distclean clean testclean test
 
 install:: $(DOCKERFILE)
 	docker build -t $(TAG) -f $(DOCKERFILE) $(DOCKER_BUILD_OPTS) .

--- a/riak/README.md
+++ b/riak/README.md
@@ -98,3 +98,16 @@ Automatic loading of bucket types is supported in this image. It supports both T
 To use the schema bootstrapping with `docker-compose` you need to set up a volume named "schemas" that contains all the schema files. This volume will be mounted in the container at path `/etc/riak/schemas/`. The following will create a volume named `schemas` and copy the contents of `$(pwd)/schemas/*` to the volume. When `docker-compose up` is run, the sql and dt files will be translated into `riak-admin bucket type create` and activate commands based on the `basename` of the file.
 
     $ docker run --rm -it -v schemas:/etc/riak/schemas -v $(pwd)/schemas:/tmp/schemas alpine cp /tmp/schemas/* /etc/riak/schemas/
+
+### Adding pre and poststart hooks
+
+The Riak Docker container contains directories for pre and poststart hook scripts. They are:
+
+* `/etc/riak/prestart.d`
+* `/etc/riak/poststart.d`
+
+To add functionality to the container, either create a new image derived from this one which adds your hook scripts via `COPY` or mount a volume that follows a naming convention like this:
+
+    docker run -v $(pwd)/hooks/my-custom-poststart.sh:/etc/riak/poststart.d/10-my-custom-hook.sh basho/riak-ts
+
+This will mount your custom hook script in the `/etc/riak/poststart.d` directory where it will be sourced into the main boostrapping script after the Riak node has started and `wait-for-service` has returned, indicating the node is ready for use. Example scripts can be found in the [overlays/prestart.d](overlays/prestart.d) and [overlays/poststart.d](overlays/poststart.d) directories.

--- a/riak/overlays/poststart.d/01-bootstrap-schemas.sh
+++ b/riak/overlays/poststart.d/01-bootstrap-schemas.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$RIAK_FLAVOR" == "TS" ]; then
+  # Create TS buckets
+  echo "Looking for CREATE TABLE schemas in $SCHEMAS_DIR..."
+  for f in $(find $SCHEMAS_DIR -name *.sql -print); do
+    BUCKET_NAME=$(basename -s .sql $f)
+    BUCKET_DEF=$(cat $f)
+    $RIAK_ADMIN bucket-type create $BUCKET_NAME '{"props":{"table_def":"'$BUCKET_DEF'"}}'
+    $RIAK_ADMIN bucket-type activate $BUCKET_NAME
+  done
+fi

--- a/riak/overlays/poststart.d/02-bootstrap-datatypes.sh
+++ b/riak/overlays/poststart.d/02-bootstrap-datatypes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Create KV bucket types
+echo "Looking for datatypes in $SCHEMAS_DIR..."
+for f in $(find $SCHEMAS_DIR -name *.dt -print); do
+  BUCKET_NAME=$(basename -s .dt $f)
+  BUCKET_DT=$(cat $f)
+  $RIAK_ADMIN bucket-type create $BUCKET_NAME '{"props":{"datatype":"'$BUCKET_DT'"}}'
+  $RIAK_ADMIN bucket-type activate $BUCKET_NAME
+done

--- a/riak/overlays/poststart.d/99-join-cluster.sh
+++ b/riak/overlays/poststart.d/99-join-cluster.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Maybe join to a cluster
+IN_CLUSTER="$($RIAK_ADMIN cluster status --format=json | jq -r --arg coordinator $COORDINATOR_NODE_HOST '.[] | select(.type == "table") | .table[] | select(.node | contains($coordinator))')"
+if [[ "$IN_CLUSTER" == "" && "$COORDINATOR_NODE_HOST" != "$HOST" ]]; then
+  # Not already in this cluster, so join
+  echo "Connecting to cluster coordinator $COORDINATOR_NODE"
+  curl -sSL $HOST:8098/admin/control/clusters/default/join/riak@$COORDINATOR_NODE_HOST
+fi

--- a/riak/overlays/prestart.d/00-update-riak-conf.sh
+++ b/riak/overlays/prestart.d/00-update-riak-conf.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i -r "s#nodename = (.*)#nodename = riak@$HOST#g" $RIAK_CONF
+sed -i -r "s#distributed_cookie = (.*)#distributed_cookie = $CLUSTER_NAME#g" $RIAK_CONF
+sed -i -r "s#listener\.protobuf\.internal = (.*)#listener.protobuf.internal = $HOST:8087#g" $RIAK_CONF
+sed -i -r "s#listener\.http\.internal = (.*)#listener.http.internal = $HOST:8098#g" $RIAK_CONF

--- a/riak/overlays/riak-cluster.sh
+++ b/riak/overlays/riak-cluster.sh
@@ -1,49 +1,26 @@
 #!/bin/bash
 
-RIAK=/usr/sbin/riak
-RIAK_CONF=/etc/riak/riak.conf
-RIAK_ADMIN=/usr/sbin/riak-admin
-SCHEMAS_DIR=/etc/riak/schemas/
+export RIAK=/usr/sbin/riak
+export RIAK_CONF=/etc/riak/riak.conf
+export RIAK_ADMIN=/usr/sbin/riak-admin
+export SCHEMAS_DIR=/etc/riak/schemas/
 
-CLUSTER_NAME=${CLUSTER_NAME:-riak}
-COORDINATOR_NODE=${COORDINATOR_NODE:-$HOSTNAME}
-HOST=$(ping -c1 $HOSTNAME | awk '/^PING/ {print $3}' | sed 's/[()]//g')||'127.0.0.1'
-COORDINATOR_NODE_HOST=$(ping -c1 $COORDINATOR_NODE | awk '/^PING/ {print $3}' | sed 's/[()]//g')||'127.0.0.1'
+export CLUSTER_NAME=${CLUSTER_NAME:-riak}
+export COORDINATOR_NODE=${COORDINATOR_NODE:-$HOSTNAME}
+export HOST=$(ping -c1 $HOSTNAME | awk '/^PING/ {print $3}' | sed 's/[()]//g')||'127.0.0.1'
+export COORDINATOR_NODE_HOST=$(ping -c1 $COORDINATOR_NODE | awk '/^PING/ {print $3}' | sed 's/[()]//g')||'127.0.0.1'
 
-sed -i -r "s#nodename = (.*)#nodename = riak@$HOST#g" $RIAK_CONF
-sed -i -r "s#distributed_cookie = (.*)#distributed_cookie = $CLUSTER_NAME#g" $RIAK_CONF
-sed -i -r "s#listener\.protobuf\.internal = (.*)#listener.protobuf.internal = $HOST:8087#g" $RIAK_CONF
-sed -i -r "s#listener\.http\.internal = (.*)#listener.http.internal = $HOST:8098#g" $RIAK_CONF
+PRESTART=$(find /etc/riak/prestart.d -name *.sh -print)
+for s in $PRESTART; do
+  . $s
+done
 
 $RIAK start
 $RIAK_ADMIN wait-for-service riak_kv
 
-if [ "$RIAK_FLAVOR" == "TS" ]; then
-  # Create TS buckets
-  echo "Looking for CREATE TABLE schemas in $SCHEMAS_DIR..."
-  for f in $(find $SCHEMAS_DIR -name *.sql -print); do
-    BUCKET_NAME=$(basename -s .sql $f)
-    BUCKET_DEF=$(cat $f)
-    $RIAK_ADMIN bucket-type create $BUCKET_NAME '{"props":{"table_def":"'$BUCKET_DEF'"}}'
-    $RIAK_ADMIN bucket-type activate $BUCKET_NAME
-  done
-fi
-
-# Create KV bucket types
-echo "Looking for datatypes in $SCHEMAS_DIR..."
-for f in $(find $SCHEMAS_DIR -name *.dt -print); do
-  BUCKET_NAME=$(basename -s .dt $f)
-  BUCKET_DT=$(cat $f)
-  $RIAK_ADMIN bucket-type create $BUCKET_NAME '{"props":{"datatype":"'$BUCKET_DT'"}}'
-  $RIAK_ADMIN bucket-type activate $BUCKET_NAME
+POSTSTART=$(find /etc/riak/poststart.d -name *.sh -print)
+for s in $POSTSTART; do
+  . $s
 done
-
-# Maybe join to a cluster
-IN_CLUSTER="$($RIAK_ADMIN cluster status --format=json | jq -r --arg coordinator $COORDINATOR_NODE_HOST '.[] | select(.type == "table") | .table[] | select(.node | contains($coordinator))')"
-if [[ "$IN_CLUSTER" == "" && "$COORDINATOR_NODE_HOST" != "$HOST" ]]; then
-  # Not already in this cluster, so join
-  echo "Connecting to cluster coordinator $COORDINATOR_NODE"
-  curl -sSL $HOST:8098/admin/control/clusters/default/join/riak@$COORDINATOR_NODE_HOST
-fi
 
 tail -n 1024 -f /var/log/riak/console.log

--- a/riak/overlays/riak-common.Dockerfile
+++ b/riak/overlays/riak-common.Dockerfile
@@ -21,6 +21,9 @@ VOLUME /var/lib/riak
 # Install custom start script
 COPY {{$dir}}/riak-cluster.sh /usr/lib/riak/riak-cluster.sh
 RUN chmod a+x /usr/lib/riak/riak-cluster.sh
+# Install custom hooks
+COPY {{$dir}}/prestart.d /etc/riak/prestart.d
+COPY {{$dir}}/poststart.d /etc/riak/poststart.d
 
 # Prepare for bootstrapping schemas
 RUN mkdir -p /etc/riak/schemas


### PR DESCRIPTION
Addresses an issue @paegun had that there wasn't a clear place to extend bootstrapping behavior. Added a pre and poststart directory and pulled content from the `riak-cluster.sh` into the respective directories where those scripts can be separated. Now to add functionality to the container, one just needs to add a new script to `/etc/riak/[pre|post]start.d/*.sh` and it will be sourced by `riak-cluster.sh` at the appropriate time.
